### PR TITLE
Consume `facility` information returned from API.

### DIFF
--- a/omnia_timeseries_sdk/resources.py
+++ b/omnia_timeseries_sdk/resources.py
@@ -372,16 +372,19 @@ class TimeSeries(OmniaResource):
         ISO formatted date-time of when the time series was last changed
     asset_id : str, optional
         Id of the asset this times eries belong to
+    facility : str, optional
+        Facility this timeseries belongs to. Can be a SID code, SAP code or NPDID registered in the Common Library API.
     omnia_client : OmniaClient, optional
         OMNIA client.
 
     """
     def __init__(self, id: str = None, external_id: str = None, name: str = None, description: str = None,
                  step: bool = False, unit: str = None, created_time: str = None, changed_time: str = None,
-                 asset_id: str = None, omnia_client = None):
+                 asset_id: str = None, facility: str = None, omnia_client=None):
         self.id = id
         self.external_id = external_id
         self.asset_id = asset_id
+        self.facility = facility
         self.name = name
         self.description = description
         self.step = step

--- a/tests/functional/test_apiclient.py
+++ b/tests/functional/test_apiclient.py
@@ -27,6 +27,7 @@ def test_retrieve(client, new_timeseries):
     assert ts.unit == new_timeseries.unit
     assert ts.asset_id is None
     assert ts.external_id is None
+    assert ts.facility is None
     assert not ts.step
 
 
@@ -42,6 +43,7 @@ def test_retrieve_multiple(client, new_timeseries):
     assert ts.unit == new_timeseries.unit
     assert ts.asset_id is None
     assert ts.external_id is None
+    assert ts.facility is None
     assert not ts.step
 
 


### PR DESCRIPTION
# Summary

## Fixed
Version 1.6 the API returns an additional data field `facility`. This change also affected earlier API versions which broke the compatibility of version `0.2.0` of `omnia-timeseries-sdk` on API version 1.5.